### PR TITLE
Add backoff retry db migration

### DIFF
--- a/migrate/backoff.go
+++ b/migrate/backoff.go
@@ -1,6 +1,6 @@
 package migrate
 
-import backoff "gopkg.in/cenkalti/backoff.v1"
+import backoff "gopkg.in/cenkalti/backoff.v2"
 
 func (m *Module) SetBackOff(b backoff.BackOff) {
 	m.backoff = b

--- a/migrate/backoff.go
+++ b/migrate/backoff.go
@@ -1,0 +1,7 @@
+package migrate
+
+import backoff "gopkg.in/cenkalti/backoff.v1"
+
+func (m *Module) SetBackOff(b backoff.BackOff) {
+	m.backoff = b
+}

--- a/migrate/commands.go
+++ b/migrate/commands.go
@@ -2,7 +2,6 @@ package migrate
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/octavore/naga/service"
@@ -19,14 +18,14 @@ func (m *Module) registerCommands(c *service.Config) {
 			}
 			b, err := m.GetBackend(ctx.Args[0])
 			if err != nil {
-				log.Println("migrate:", err)
+				m.Logger.Error("migrate:", err)
 				return
 			}
 			err = backoff.RetryNotify(b.Migrate, m.backoff, func(err error, duration time.Duration) {
-				log.Printf("can't connect to mysql: %s, will retry in %s", err, duration)
+				m.Logger.Warningf("can't connect to mysql: %s, will retry in %s", err, duration)
 			})
 			if err != nil {
-				log.Println("migrate:", err)
+				m.Logger.Error("migrate:", err)
 			}
 		},
 	})
@@ -41,16 +40,16 @@ func (m *Module) registerCommands(c *service.Config) {
 			dbname := ctx.Args[0]
 			b, err := m.GetBackend(dbname)
 			if err != nil {
-				log.Println("migrate:", err)
+				m.Logger.Error("migrate:", err)
 				return
 			}
 			err = b.Reset()
 			if err != nil {
-				log.Println("migrate:", err)
+				m.Logger.Error("migrate:", err)
 			}
 			err = b.Migrate()
 			if err != nil {
-				log.Println("migrate:", err)
+				m.Logger.Error("migrate:", err)
 			}
 		},
 	})

--- a/migrate/commands.go
+++ b/migrate/commands.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/octavore/naga/service"
-	backoff "gopkg.in/cenkalti/backoff.v1"
+	"gopkg.in/cenkalti/backoff.v2"
 )
 
 func (m *Module) registerCommands(c *service.Config) {

--- a/migrate/module.go
+++ b/migrate/module.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"database/sql"
 
+	"github.com/cenkalti/backoff"
 	"github.com/octavore/naga/service"
 	"github.com/rubenv/sql-migrate"
 
@@ -21,6 +22,7 @@ type Module struct {
 
 	config          Config
 	migrationSource migrate.MigrationSource
+	backoff         backoff.BackOff
 
 	suffixForTest string
 	env           service.Environment
@@ -45,6 +47,7 @@ func (m *Module) Init(c *service.Config) {
 
 	c.Setup = func() error {
 		m.env = c.Env()
+		m.backoff = &backoff.StopBackOff{}
 		err := m.Config.ReadConfig(&m.config)
 		if m.config.MigrationsTable != "" {
 			migrate.SetTable(m.config.MigrationsTable)

--- a/migrate/module.go
+++ b/migrate/module.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/cenkalti/backoff.v2"
 
 	"github.com/octavore/nagax/config"
+	"github.com/octavore/nagax/logger"
 )
 
 func init() {
@@ -19,6 +20,7 @@ func init() {
 type Module struct {
 	Config *config.Module
 	DB     *sql.DB
+	Logger logger.Logger
 
 	config          Config
 	migrationSource migrate.MigrationSource

--- a/migrate/module.go
+++ b/migrate/module.go
@@ -3,9 +3,9 @@ package migrate
 import (
 	"database/sql"
 
-	"github.com/cenkalti/backoff"
 	"github.com/octavore/naga/service"
 	"github.com/rubenv/sql-migrate"
+	"gopkg.in/cenkalti/backoff.v2"
 
 	"github.com/octavore/nagax/config"
 )


### PR DESCRIPTION
Add retry to `Migrate` module by integrating with https://github.com/cenkalti/backoff.

Also, upgrade logging in migrate module to use `Logging`.